### PR TITLE
Fix ENV creation in the release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           java-version: 11
       - name: Set version env variable
-        run: echo ::set-env name=VERSION::$((grep -w "version" | cut -d= -f2) < gradle.properties | cut -d- -f1)
+        run: echo "VERSION=$((grep -w 'version' | cut -d= -f2) < gradle.properties | cut -d- -f1)" >> $GITHUB_ENV
       - name: Pre release depenency version update
         env:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}


### PR DESCRIPTION
## Purpose
$title

## Approach
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

