### PR TITLE
Update flag for coverage format

### DIFF
--- a/transaction-ballerina/build.gradle
+++ b/transaction-ballerina/build.gradle
@@ -59,7 +59,7 @@ ballerina {
     packageOrganization = packageOrg
     module = packageName
     langVersion = ballerinaLangVersion
-    testCoverageParam = "--code-coverage --jacoco-xml --includes=ballerinai.transaction.*:org.ballerinalang.stdlib.transaction.*"
+    testCoverageParam = "--code-coverage --coverage-format=xml --includes=ballerinai.transaction.*:org.ballerinalang.stdlib.transaction.*"
 }
 
 task updateTomlFiles {


### PR DESCRIPTION
## Purpose
Update flag for coverage format from '--jacoco-xml' to '--coverage-format=xml'

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests