### PR TITLE
Add tests to check the type narrowing of a query in a transaction scenario

### DIFF
--- a/transaction-ballerina/tests/retry_transaction_stmt.bal
+++ b/transaction-ballerina/tests/retry_transaction_stmt.bal
@@ -312,3 +312,26 @@ function getPrevInfoInNested() returns string|error {
     }
     return str;
 }
+
+@test:Config
+function testTypeNarrowingQueryWithRetry() {
+    int? i = 3;
+    int|int[] result;
+
+    transaction {
+        if i is () {
+            any|error out = commit;
+        } else {
+            rollback;
+        }
+    }
+
+    retry {
+        result = i is int ?
+            from var _ in [1, 2]
+            where i + 2 == 5
+            select 2 : 2;
+    }
+
+    test:assertEquals([2, 2], result);
+}

--- a/transaction-ballerina/tests/transaction_stmt.bal
+++ b/transaction-ballerina/tests/transaction_stmt.bal
@@ -730,3 +730,23 @@ function testBreakWithinTransactionToOuterLoop() {
     test:assertEquals(str, "Loop continued with digit: 1 ->Loop continued with digit: 2 " +
     "->Loop continued with digit: 3 ->Loop broke with digit: 4");
 }
+
+@test:Config
+function testTypeNarrowingQueryWithTransaction() {
+    int? i = 3;
+    int|int[] result;
+
+    transaction {
+        if i is () {
+            result = 2;
+            any|error out = commit;
+        } else {
+            result = i is int ?
+                from var _ in [1, 2]
+                where i + 2 == 5
+                select 2 : 2;
+        }
+    }
+
+    test:assertEquals([2, 2], result);
+}


### PR DESCRIPTION
## Purpose
This test is added along with the change made in https://github.com/ballerina-platform/ballerina-lang/pull/41743 to assert the type narrowing behavior in a retry block.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/ballerina-platform/ballerina-lang/pull/41743

## Test environment
Ballerina 2201.8.3 (Swan Lake Update 8)
OS: macOS 14.1.1 23B81
JDK: openjdk 17.0.8 2023-07-18
 