### PR TITLE
[DO NOT MERGE] Test Java 21/25 compatibility via ballerina-library dev workflows

### DIFF
--- a/.github/workflows/build-with-bal-test-graalvm.yml
+++ b/.github/workflows/build-with-bal-test-graalvm.yml
@@ -30,7 +30,7 @@ jobs:
     call_stdlib_workflow:
         name: Run StdLib Workflow
         if: ${{ github.event_name != 'schedule' || (github.event_name == 'schedule' && github.repository_owner == 'ballerina-platform') }}
-        uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-template.yml@main
+        uses: ballerina-platform/ballerina-library/.github/workflows/build-with-bal-test-graalvm-template.yml@dev
         with:
             lang_tag: ${{ inputs.lang_tag }}
             lang_version: ${{ inputs.lang_version }}

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadMultipleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadMultipleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadMultipleFiles')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('transaction-ballerina:build')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,14 @@ release {
     }
 }
 
-tasks.named('build') {
-    dependsOn('transaction-ballerina:build')
+if (tasks.names.contains('build')) {
+    tasks.named('build') {
+        dependsOn('transaction-ballerina:build')
+
+    }
+} else {
+    tasks.register('build') {
+        dependsOn('transaction-ballerina:build')
+
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,14 @@ org.gradle.caching=true
 group=org.ballerinalang
 version=1.12.1-SNAPSHOT
 ballerinaLangVersion=2201.12.0
+jacocoVersion=0.8.14
 
 checkStylePluginVersion=10.12.0
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
-ballerinaGradlePluginVersion=2.3.0
+releasePluginVersion=3.1.0
+ballerinaGradlePluginVersion=4.0.0
 testngVersion=7.6.1
 slf4jVersion=1.7.30
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,8 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,16 +28,16 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.13.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'transaction'
 include(':build-config:checkstyle')
 include ':transaction-native', ':transaction-ballerina', ':transaction-test-utils', ':transaction-negative-tests'
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/help/legal-terms-of-use'
+        termsOfUseAgree = 'yes'
     }
 }

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -21,13 +21,4 @@
         <Method name="reorderInfoRecord" />
         <Bug pattern="DLS_DEAD_LOCAL_STORE" />
     </Match>
-    <!-- gradle9-rollout: temporary suppression pending review: surfaced by the SpotBugs plugin version bump needed for Gradle 9 / Java 25 support (see PR body) — pre-existing code, not introduced by this PR -->
-    <Match>
-        <Class name="org.ballerinalang.stdlib.transaction.GetHostAddress"/>
-        <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
-    </Match>
-    <Match>
-        <Class name="org.ballerinalang.stdlib.transaction.Utils"/>
-        <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
-    </Match>
 </FindBugsFilter>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -21,4 +21,13 @@
         <Method name="reorderInfoRecord" />
         <Bug pattern="DLS_DEAD_LOCAL_STORE" />
     </Match>
+    <!-- gradle9-rollout: temporary suppression pending review: surfaced by the SpotBugs plugin version bump needed for Gradle 9 / Java 25 support (see PR body) — pre-existing code, not introduced by this PR -->
+    <Match>
+        <Class name="org.ballerinalang.stdlib.transaction.GetHostAddress"/>
+        <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
+    </Match>
+    <Match>
+        <Class name="org.ballerinalang.stdlib.transaction.Utils"/>
+        <Bug pattern="THROWS_METHOD_THROWS_RUNTIMEEXCEPTION"/>
+    </Match>
 </FindBugsFilter>

--- a/transaction-ballerina/build.gradle
+++ b/transaction-ballerina/build.gradle
@@ -16,6 +16,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -46,8 +53,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml"

--- a/transaction-native/build.gradle
+++ b/transaction-native/build.gradle
@@ -51,7 +51,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true

--- a/transaction-native/src/main/java/org/ballerinalang/stdlib/transaction/GetHostAddress.java
+++ b/transaction-native/src/main/java/org/ballerinalang/stdlib/transaction/GetHostAddress.java
@@ -37,7 +37,7 @@ public class GetHostAddress {
         return StringUtils.fromString(getLocalHostLANAddress().getHostAddress());
     }
 
-    private static InetAddress getLocalHostLANAddress() throws RuntimeException {
+    private static InetAddress getLocalHostLANAddress() {
         try {
             InetAddress candidateAddress = null;
             // Iterate all NICs (network interface cards)...
@@ -76,7 +76,7 @@ public class GetHostAddress {
             }
             return jdkSuppliedAddress;
         } catch (Exception e) {
-            throw new RuntimeException("Failed to determine LAN address: " + e, e);
+            throw new IllegalStateException("Failed to determine LAN address: " + e, e);
         }
     }
 }

--- a/transaction-native/src/main/java/org/ballerinalang/stdlib/transaction/Utils.java
+++ b/transaction-native/src/main/java/org/ballerinalang/stdlib/transaction/Utils.java
@@ -326,7 +326,7 @@ public class Utils {
         return StringUtils.fromString(getLocalHostLANAddress().getHostAddress());
     }
 
-    private static InetAddress getLocalHostLANAddress() throws RuntimeException {
+    private static InetAddress getLocalHostLANAddress() {
         try {
             InetAddress candidateAddress = null;
             // Iterate all NICs (network interface cards)...
@@ -365,7 +365,7 @@ public class Utils {
             }
             return jdkSuppliedAddress;
         } catch (Exception e) {
-            throw new RuntimeException("Failed to determine LAN address: " + e, e);
+            throw new IllegalStateException("Failed to determine LAN address: " + e, e);
         }
     }
 

--- a/transaction-negative-tests/build.gradle
+++ b/transaction-negative-tests/build.gradle
@@ -16,6 +16,13 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
 
 apply plugin: 'java'
 
@@ -105,6 +112,7 @@ def setExecPath(configTomlFile, originalConfigFileText, distributionBinPath) {
 }
 
 task ballerinaNegativeTests {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     inputs.dir file(project.projectDir)
     dependsOn(copyToLib)
     dependsOn(initializeVariables)
@@ -121,7 +129,7 @@ task ballerinaNegativeTests {
         def distributionBinPath =  "$project.rootDir/target/ballerina-runtime/bin"
         
         setExecPath(configTomlFile, originalConfigFileText, distributionBinPath)
-        exec {
+        execHelper.execOperations.exec {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {

--- a/transaction-test-utils/build.gradle
+++ b/transaction-test-utils/build.gradle
@@ -51,7 +51,7 @@ spotbugsMain {
     def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs")
     reports {
         html.enabled true
         text.enabled = true


### PR DESCRIPTION
## Summary
**DO NOT MERGE — this PR exists only to run CI against the `ballerina-library` `dev` branch workflows for Java 21/25 compatibility testing.**

Combines the gradle upgrade from PR 1 with pointing this repo's `ballerina-library` reusable workflows at `dev` instead of `main`. Close (don't merge) once the `dev` branch changes land upstream in `ballerina-library`'s `main` — PR 1 is the one that should land here.

## Test plan
- [ ] CI passes on the `dev` ballerina-library workflows for Java 21 and Java 25